### PR TITLE
Update path to private key file

### DIFF
--- a/src/db/configs/example.json
+++ b/src/db/configs/example.json
@@ -24,7 +24,7 @@
         "auth_login_url": "http://localhost:9001/platform/login.php",
         "auth_token_url": "http://localhost/platform/token.php",
         "key_set_url": "http://localhost/platform/jwks.php",
-        "private_key_file": "/keys/private.key",
+        "private_key_file": "/private.key",
         "kid": "58f36e10-c1c1-4df0-af8b-85c857d1634f",
         "deployment": [
             "8c49a5fa-f955-405e-865f-3d7e959e809f"


### PR DESCRIPTION
The default path to the private key file in the config was not correct. I updated the config file it the example platform can now be run and _used_ without requiring modifications.