### PR TITLE
Adding a readme note regarding direct request to the index.php file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ To view the example platform, go to http://localhost:9001/platform
 
 **Note:** The platform is for example purposes only and not a full platform library.
 
+**Note:** If the platform does not load in your browser, try going to http://localhost:9001/platform/index.php.
+
 # Contributing
 If you have improvements, suggestions or bug fixes, feel free to make a pull request or issue and someone will take a look at it.
 


### PR DESCRIPTION
In my Docker setup, there was some config issue that prevented the server from automatically using index.php as the file, when requesting localhost:9001/platform/

This just adds a tip to the readme to suggest going directly to index.php if nothing loads.

It's possible there's a config setting in the docker stuff in the repo which might fix this